### PR TITLE
Add gitattributes to handle line endings regardless of OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default line ending managment behavior, in case people don't have core.autocrlf set.
+* text=auto


### PR DESCRIPTION
Handling line endings can be tricky when using git on multiple operating systems. It depends on the `git config core.autocrlf` setting. This PR ensures consistent behavior regardless of the operating system used. For more information see: [Configuring Git to handle line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)